### PR TITLE
Fix issue running on ansible controller host with python3

### DIFF
--- a/templates/config.j2
+++ b/templates/config.j2
@@ -2,7 +2,7 @@
 ## https://github.com/bitly/oauth2_proxy
 ## https://github.com/bitly/oauth2_proxy/blob/master/contrib/oauth2_proxy.cfg.example
 
-{% for k,v in oauth2_proxy_config.iteritems() %}
+{% for k,v in oauth2_proxy_config.items() %}
 {% if v is string %}
 {{ k }} = "{{ v }}"
 {% else %}


### PR DESCRIPTION
Replace iteritems() with items() as per https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/no-dict-iteritems.html and https://github.com/Igorshp/ansible-oauth2-proxy/commit/4773c7114d12adcde4fd8cd3989ef89b1700927f.