### PR TITLE
Use newer cookie_domains config for oauth2-proxy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ oauth2_proxy_config:
     provider: "github"
     email_domains: "*"
     cookie_secure: false
-    cookie_domain: "localhost:5000"
+    cookie_domains: "localhost:5000"
     cookie_secret: "{{ 'COOK_SECRET' | b64encode }}"
     client_id: "YOUR_CLIENT_ID"
     client_secret: "CLIENT_SECERET"


### PR DESCRIPTION
Using a recent version of oauth2-proxy fails because of the 'cookie_domain' config - it needs to be 'cookie_domains'.

This doesn't play nicely with old versions of oauth2-proxy, but a variable override should suffice(if you use the default ansible hash_behaviour setting).