### PR TITLE
Fix test to use newer cookie_domains option

### DIFF
--- a/tests/role.yml
+++ b/tests/role.yml
@@ -24,7 +24,7 @@
         provider: "github"
         email_domains: "*"
         cookie_secure: false
-        cookie_domain: "localhost:5000"
+        cookie_domains: "localhost:5000"
         cookie_secret: "{{ 'COOK_SECRET' | b64encode }}"
         client_id: "YOUR_CLIENT_ID"
         client_secret: "CLIENT_SECERET"


### PR DESCRIPTION
I neglected to update the test when I updated the cookie_domains option. This combined with the oauth2-proxy executable path fix should fix the TravisCI failures.