### PR TITLE
Verify oauth sha256sum against provided package sha256sum

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,9 @@
 ---
 
 oauth2_proxy_version: "v7.1.3"
-oauth2_proxy_http: "https://github.com/oauth2-proxy/oauth2-proxy/releases/download/{{ oauth2_proxy_version }}/oauth2-proxy-{{ oauth2_proxy_version }}.linux-amd64.tar.gz"
-oauth2_proxy_http_sha256: "a491ca18059848c356935fe2ca9e665faafe4bba3ee1ecbac5a5f5f193195a82"
+oauth2_proxy_http_prefix: "https://github.com/oauth2-proxy/oauth2-proxy/releases/download/{{ oauth2_proxy_version }}"
+oauth2_proxy_http: "{{ oauth2_proxy_http_prefix }}/oauth2-proxy-{{ oauth2_proxy_version }}.linux-amd64.tar.gz"
+oauth2_proxy_http_sha256sum: "{{ oauth2_proxy_http_prefix }}/oauth2-proxy-{{ oauth2_proxy_version }}.linux-amd64-sha256sum.txt"
 oauth2_user: "oauth2"
 oauth2_dir: "/opt/oauth2_proxy"
 oauth2_tmp_dir: "{{ oauth2_dir }}/tmp"
@@ -11,9 +12,9 @@ oauth2_config_dir: "/etc/oauth2_proxy"
 oauth2_config_path: "{{ oauth2_config_dir }}/oauth2_config.cfg"
 oauth2_config_param_prefix: "--" # set to - for older versions
 oauth2_compress_filename: "{{ oauth2_proxy_http | basename }}"
-oauth2_version: "{{ oauth2_compress_filename |replace('.tar.gz', '') }}"
-oauth2_version_dir: "{{ oauth2_dir }}/{{ oauth2_version }}"
+oauth2_version_dir: "{{ oauth2_dir }}/{{ oauth2_proxy_version }}"
 oauth2_filename: "oauth2-proxy-{{ oauth2_proxy_version }}.linux-amd64/oauth2-proxy"
+oauth2_sha256sum_filename: "oauth2-proxy-{{ oauth2_proxy_version }}.linux-amd64/sha256sum.txt"
 oauth2_init_system: "systemd" # could be `systemd`, `sysv` or `no` for no setup
 oauth2_identifier: "oauth2-proxy"
 oauth2_systemd_unit_path: "/etc/systemd/system/{{ oauth2_identifier }}.service"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,7 +55,7 @@
     owner: "{{ oauth2_user }}"
 
 - name: Get expected sha256sum from downloaded file
-  command: "cat '{{ oauth2_version_dir }}/{{ oauth2_sha256sum_filename}}'"
+  command: "cat '{{ oauth2_version_dir }}/{{ oauth2_sha256sum_filename }}'"
   register: oauth_expected_sha256sum
   changed_when: False # we don't want this to be noticed as a change
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,6 @@
 - name: Download compressed oauth2 binary
   get_url:
     url: "{{ oauth2_proxy_http }}"
-    sha256sum: "{{ oauth2_proxy_http_sha256 | default(omit) }}"
     dest: "{{ oauth2_tmp_dir }}/{{ oauth2_compress_filename }}"
     owner: "{{ oauth2_user }}"
 
@@ -41,7 +40,30 @@
     src: "{{ oauth2_tmp_dir }}/{{ oauth2_compress_filename }}"
     dest: "{{ oauth2_version_dir }}/"
     creates: "{{ oauth2_version_dir }}/{{ oauth2_filename }}"
-    copy: no
+    remote_src: yes
+
+- name: Get sha256sum of decompressed oauth2 binary
+  stat:
+    path: "{{ oauth2_version_dir }}/{{ oauth2_filename }}"
+    checksum_algorithm: "sha256"
+  register: oauth2_stat
+
+- name: Download oauth2 binary sha256sum
+  get_url:
+    url: "{{ oauth2_proxy_http_sha256sum }}"
+    dest: "{{ oauth2_version_dir }}/{{ oauth2_sha256sum_filename }}"
+    owner: "{{ oauth2_user }}"
+
+- name: Get expected sha256sum from downloaded file
+  command: "cat '{{ oauth2_version_dir }}/{{ oauth2_sha256sum_filename}}'"
+  register: oauth_expected_sha256sum
+  changed_when: False # we don't want this to be noticed as a change
+
+# oauth2-proxy provides the sha256sum of the decompressed binary, not the archive itself
+- name: Verify sha256sum of decompressed oauth binary
+  fail:
+    msg: "Failure, sha256sum of {{ oauth2_version_dir }}/{{ oauth2_filename }} is not correct."
+  when: oauth_expected_sha256sum.stdout is not match(oauth2_stat.stat.checksum)
 
 - name: Create current symlink
   file:


### PR DESCRIPTION
This change downloads the sha256sum from the oauth download page and compares it against the sha256sum of the downloaded and decompressed oauth binary.

I feel that oauth should provide the sha256sum of the tarball, but until they change this, this more complicated approach is necessary.

This should make updating the oauth version in this role quicker, and hopefully closes #10.